### PR TITLE
Improve HF integration

### DIFF
--- a/core/vision_encoder/model.py
+++ b/core/vision_encoder/model.py
@@ -16,6 +16,8 @@ import torch
 import torch.nn as nn
 from torch.nn import functional as F
 
+from huggingface_hub import PyTorchModelHubMixin
+
 from core.vision_encoder.pev1 import TextTransformer, VisionTransformer
 
 
@@ -78,7 +80,11 @@ class CLIPTextCfg:
     norm_type: str = "layernorm"  # "layernorm" or "rmsnorm"
 
 
-class CLIP(nn.Module):
+class CLIP(nn.Module,
+           PyTorchModelHubMixin,
+           repo_url="https://github.com/facebookresearch/perception_models",
+           pipeline_tag="image-feature-extraction",
+           license="apache-2.0"):
     def __init__(
         self,
         embed_dim: int,


### PR DESCRIPTION
Hi @dbolya and team!

This PR improves the integration with the 🤗 hub, by making the main class inherit from the `[PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/en/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin)` class.

Benefits:
- weights are serialized in [safetensors](https://github.com/huggingface/safetensors) format, instead of pickle
- download stats work
- the class automatically inhertis the `from_pretrained`, `save_pretrained` and `push_to_hub` methods.

You can push weights to the hub as follows:

```python
from model import CLIP
from huggingface_hub import hf_hub_download
import torch

# load model
model = CLIP(**model_cfg)

# equip with weights
filepath = hf_hub_download(repo_id="", filename="")
state_dict = torch.load(filepath, map_location="cpu")
model.load_state_dict(state_dict)

# push to the hub
model.push_to_hub("facebook/PE-Core-L14-336")

# now anyone can use it like so:
model = CLIP.from_pretrained("facebook/PE-Core-L14-336")
```

It would be great if you could try this out, and overwrite the weights of the model repository with the updated ones.