### PR TITLE
Fix activation checkpointing for vision model.

### DIFF
--- a/core/distributed.py
+++ b/core/distributed.py
@@ -479,7 +479,7 @@ def parallelize_model(
                 layer_id,
                 resblock,
             ) in model.vision_model.transformer.resblocks.named_children():
-                resblock = checkpoint_wrapper(resblock, preserve_rng_state=False)
+                resblock = checkpoint_wrapper(resblock, preserve_rng_state=True)
                 model.vision_model.transformer.resblocks.register_module(
                     layer_id, resblock
                 )


### PR DESCRIPTION
In PLM stage 2 and 3, PE is unfrozen with `drop_path` enabled.
This fix reuses rng_state from original forward pass for activation recompuation during backward pass.