### PR TITLE
Fix image indexing in packed sequence

### DIFF
--- a/apps/plm/generate.py
+++ b/apps/plm/generate.py
@@ -297,8 +297,9 @@ class PackedCausalTransformerGenerator:
                 self.device
             )
             assert tokens.shape[0] == 1
-            offsets = torch.roll(lengths.cpu(), shifts=1, dims=-1).numpy()
+            offsets = torch.roll(lengths.cpu(), shifts=1, dims=-1)
             offsets[0] = 0
+            offsets = torch.cumsum(offsets, dim=0).numpy()
             num_chunks_seq = 0
             image_id_offset = 0
             for image_id, offset in enumerate(offsets):
@@ -334,14 +335,15 @@ class PackedCausalTransformerGenerator:
         images, image_pos_index, num_chunks = self.prepare_media_inputs(
             tokens, lengths, images, image_patch_text_ids, num_image_chunks
         )
+        is_batched = lengths.size(0) > 1
         prefill_out = self.model.forward(
             tokens,
             tok_idx=self.prefill_tok_id,
-            mask="causal",
+            mask=self.prefill_mask if is_batched else "causal",
             images=images,
             image_pos_index=image_pos_index,
             num_chunks=num_chunks,
-            attn_impl="sdpa",
+            attn_impl="flex_attention" if is_batched else "sdpa",
         )
         self.setup_generation(lengths=lengths)
         return prefill_out


### PR DESCRIPTION
Batched/packed inference is already supported, and this commit simply fixed one bug in image feature indexing. During batch inference, all sequences are packed into one single sequence. To navigate the position of image tokens, `image_pos_index` stores the global index of image tokens, `image_patch_text_ids` are their local indices in each sequence, and they are convertible by offsets--the cumulative length of all previous sequences. Currently if we only use `batch_size=1`, the cumulation is unnecessary. However when performing (packed) batch inference, index cumulation is needed. These are then used to stitch image tokens into the text sequence during the models' forward process at prefilling stage.

Also fallback to sdpa causal attention implementation when `batch_size=1` for faster inference.